### PR TITLE
複数ドメイン指定時の挙動を修正しました

### DIFF
--- a/dns_tmpdns.sh
+++ b/dns_tmpdns.sh
@@ -5,7 +5,7 @@ dns_tmpdns_add() {
   fulldomain=$1
   txtvalue=$2
   _debug "docker run"
-  exists=`docker inspect -f '{{.Config.Cmd}}' tmpdns | awk '{print substr($0, 3,length($0)-4)}'` || true
+  exists=`docker inspect -f '{{.Config.Cmd}}' tmpdns | awk '{print substr($0, 2,length($0)-2)}'` || true
   docker rm -f tmpdns || true
   docker run -d -p 53:53/udp --name tmpdns binzume/tmpdns $exists "$fulldomain.:txt:$txtvalue"
 }


### PR DESCRIPTION
APIで動的にNSレコードの変更が出来ないネームサーバのサービスを使っていたのでLet's Encryptのワイルドカード証明書は諦めていたのですが、こちらのリポジトリと出会って簡単に実現出来てびっくりしました。

NSレコードだけ一時的に立てたDNSサーバに向けてしまえば良かったんですね。その発想はありませんでした。ありがとうございます！

おそらくこのスクリプトを書かれたタイミングとは`docker inspect`の出力が異なる仕様になったのでしょうが、一点動かない箇所があったので修正しました。

https://github.com/binzume/tmpdns/blob/master/dns_tmpdns.sh

こちらの8行目、既存のコンテナのCMDを新しいコンテナのCMDに加えることで複数ドメイン指定時に複数のTXTレコードを反映させるような形になっていると思います。

自分の環境(*Docker v18.06.1-ce*)ではawkによるCMDの抜き出しがうまくいっておらず動作しない状況でした。

**CMDの取得**
```docker inspect -f '{{.Config.Cmd}}' tmpdns```
↓
```[_acme-challenge.hoge.com.:txt:xxxxx _acme-challenge.hoge.com.:txt:12345]```

**CMDの抜き出し**
```awk '{print substr($0, 3, length($0)-4)}'```
↓
```acme-challenge.hoge.com.:txt:xxxxx _acme-challenge.hoge.com.:txt:1234```

このように先頭/末尾の文字が1つ抜けて取得されてしまうため正常にTXTレコードが設定できていない状態です。

substrの引数を下記のように書き換えると正常に動作しました。

```docker inspect -f '{{.Config.Cmd}}' tmpdns | awk '{print substr($0, 2, length($0)-2)}'```

念の為*Docker v19.03.5*でも試してみましたがやはり上記と同じ結果でした。